### PR TITLE
Restricted scipy version and added tests

### DIFF
--- a/.ci_support/linux_64_python3.6.____cpython.yaml
+++ b/.ci_support/linux_64_python3.6.____cpython.yaml
@@ -18,3 +18,6 @@ python:
 - 3.6.* *_cpython
 target_platform:
 - linux-64
+zip_keys:
+- - cdt_name
+  - docker_image

--- a/.ci_support/linux_64_python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_python3.7.____cpython.yaml
@@ -18,3 +18,6 @@ python:
 - 3.7.* *_cpython
 target_platform:
 - linux-64
+zip_keys:
+- - cdt_name
+  - docker_image

--- a/.ci_support/linux_64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_python3.8.____cpython.yaml
@@ -18,3 +18,6 @@ python:
 - 3.8.* *_cpython
 target_platform:
 - linux-64
+zip_keys:
+- - cdt_name
+  - docker_image

--- a/.ci_support/linux_64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpython.yaml
@@ -18,3 +18,6 @@ python:
 - 3.9.* *_cpython
 target_platform:
 - linux-64
+zip_keys:
+- - cdt_name
+  - docker_image

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,13 +36,10 @@ requirements:
 test:
   imports:
     - ale
-  requires:
-    - pytest
   commands:
     - test -e $PREFIX/lib/libale${SHLIB_EXT}  # [unix]
     - if not exist %LIBRARY_BIN%\ale.dll exit 1  # [win]
     - if not exist %LIBRARY_LIB%\ale.lib exit 1  # [win]
-    - pytest tests/pytests -vv
 
 about:
   home: https://github.com/USGS-Astrogeology/ale

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: fb9c92f59be3d089dc8908f2c7e0479a89b88171bf7b715261f83ed20d428c6c
 
 build:
-  number: 1
+  number: 2
   skip: true  # [py2k]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,6 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake >=3.15
     - eigen
-    - pytest
   host:
     - python
     - nlohmann_json
@@ -37,6 +36,8 @@ requirements:
 test:
   imports:
     - ale
+  requires:
+    - pytest
   commands:
     - test -e $PREFIX/lib/libale${SHLIB_EXT}  # [unix]
     - if not exist %LIBRARY_BIN%\ale.dll exit 1  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,7 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake >=3.15
     - eigen
+    - pytest
   host:
     - python
     - nlohmann_json
@@ -29,7 +30,7 @@ requirements:
     - python
     - python-dateutil
     - pytz
-    - scipy >=1.2.0
+    - scipy >=1.2.0,<1.6.0
     - spiceypy >=2.3.0
     - pyyaml
 
@@ -40,6 +41,7 @@ test:
     - test -e $PREFIX/lib/libale${SHLIB_EXT}  # [unix]
     - if not exist %LIBRARY_BIN%\ale.dll exit 1  # [win]
     - if not exist %LIBRARY_LIB%\ale.lib exit 1  # [win]
+    - pytest tests/pytests -vv
 
 about:
   home: https://github.com/USGS-Astrogeology/ale


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

The from_dcm and as_dcm methods were removed from scipy.transform.rotation in 1.6.0, so the current version is not compatible with scipy 1.6.0.

<!--
Please add any other relevant info below:
-->

see https://github.com/USGS-Astrogeology/ale/issues/398