### PR TITLE
Spiceypy version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - python-dateutil
     - pytz
     - scipy >=1.4.0
-    - spiceypy >=2.3.0,<=5.1.2
+    - spiceypy >=6.0.0
     - pyyaml
     - setuptools
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 727a246820b24995c00391602405e1e4e39c1b26d9c9bdb12e7aa87c7368e017
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - isd_generate = ale.isd_generate:main
   skip: true  # [py2k]
@@ -36,7 +36,7 @@ requirements:
     - python-dateutil
     - pytz
     - scipy >=1.4.0
-    - spiceypy >=2.3.0
+    - spiceypy >=2.3.0,<=5.1.2
     - pyyaml
     - setuptools
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 727a246820b24995c00391602405e1e4e39c1b26d9c9bdb12e7aa87c7368e017
 
 build:
-  number: 1
+  number: 2
   entry_points:
     - isd_generate = ale.isd_generate:main
   skip: true  # [py2k]


### PR DESCRIPTION
This ticks the version of spicypy to 6.0 and should not affect the functionality of ALE specifically, so I opted to tick the build number. 


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
